### PR TITLE
Give the score boxes more space in the smaller layout.

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -34,7 +34,9 @@ h1.title {
   @media screen and (max-width: 1080px) {
     h1.title {
       font-size: 27px;
-      margin-top: 15px; } }
+      margin-top: 15px;
+      float: none;
+      text-align: center; } }
 
 @-webkit-keyframes move-up {
   0% {
@@ -58,8 +60,12 @@ h1.title {
     top: -50px;
     opacity: 0; } }
 .scores-container {
-  float: right;
-  text-align: right; }
+  text-align: right;
+  float: right; }
+  @media screen and (max-width: 1080px) {
+    .scores-container {
+      text-align: center;
+      float: none; } }
 
 .score-container, .best-container {
   position: relative;
@@ -78,6 +84,7 @@ h1.title {
     .score-container, .best-container {
       margin-top: 0;
       padding: 15px 10px;
+      width: 44%;
       min-width: 40px; } }
   .score-container:after, .best-container:after {
     position: absolute;

--- a/style/main.scss
+++ b/style/main.scss
@@ -57,6 +57,8 @@ h1.title {
   @include smaller($mobile-threshold) {
     font-size:  27px;
     margin-top: 15px;
+    float:      none;
+    text-align: center;
   }
 }
 @include keyframes(move-up) {
@@ -71,8 +73,12 @@ h1.title {
   }
 }
 .scores-container {
-  float:      right;
   text-align: right;
+  float: right;
+  @include smaller($mobile-threshold) {
+    text-align: center;
+    float: none;
+  }
 }
 .score-container, .best-container {
   $height: 25px;
@@ -92,6 +98,7 @@ h1.title {
   @include smaller($mobile-threshold) {
     margin-top: 0;
     padding:    15px 10px;
+    width:      44%;
     min-width:  40px;
   }
 


### PR DESCRIPTION
This commit shouldn't change the larger layout, but puts the score boxes on their own line with plenty of space in the smaller version. Tested in Chrome 47 and Firefox 43.

![scoreboxes](https://cloud.githubusercontent.com/assets/3431482/12378533/6456e7b4-bd0e-11e5-8f5b-3e2b70906bd2.png)
